### PR TITLE
Ensure Postgres connections enforce SSL for remote hosts

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -102,7 +102,7 @@ jobs:
   deploy_staging:
     needs: build_and_push
     runs-on: ubuntu-latest
-  if: github.ref == 'refs/heads/testing' && vars.DEPLOY_STAGING == 'true'
+    if: github.ref == 'refs/heads/testing' && vars.DEPLOY_STAGING == 'true'
     steps:
       - name: Deploy customer service to staging
         uses: azure/webapps-deploy@v2

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -8,6 +8,21 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -18,16 +33,22 @@ jobs:
           python-version: '3.9'
 
       - name: Install and Test Customer Service
+        env:
+          DATABASE_URL: "postgresql://postgres:password@localhost:5432/test_db"
         run: |
           pip install -r backend/customer_service/requirements-dev.txt
           pytest backend/customer_service/tests/
 
       - name: Install and Test Order Service
+        env:
+          DATABASE_URL: "postgresql://postgres:password@localhost:5432/test_db"
         run: |
           pip install -r backend/order_service/requirements-dev.txt
           pytest backend/order_service/tests/
 
       - name: Install and Test Product Service
+        env:
+          DATABASE_URL: "postgresql://postgres:password@localhost:5432/test_db"
         run: |
           pip install -r backend/product_service/requirements-dev.txt
           pytest backend/product_service/tests/

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -6,6 +6,9 @@ on:
       - testing
       - main
 
+env:
+  DEPLOY_STAGING: ${{ vars.DEPLOY_STAGING }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -101,7 +104,7 @@ jobs:
   deploy_staging:
     needs: build_and_push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/testing'
+    if: github.ref == 'refs/heads/testing' && env.DEPLOY_STAGING == 'true'
     steps:
       - name: Deploy customer service to staging
         uses: azure/webapps-deploy@v2

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,0 +1,33 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - testing
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install and Test Customer Service
+        run: |
+          pip install -r backend/customer_service/requirements-dev.txt
+          pytest backend/customer_service/tests/
+
+      - name: Install and Test Order Service
+        run: |
+          pip install -r backend/order_service/requirements-dev.txt
+          pytest backend/order_service/tests/
+
+      - name: Install and Test Product Service
+        run: |
+          pip install -r backend/product_service/requirements-dev.txt
+          pytest backend/product_service/tests/

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  DEPLOY_STAGING: ${{ vars.DEPLOY_STAGING }}
+  DEPLOY_STAGING: ${{ vars.DEPLOY_STAGING || 'false' }}
 
 jobs:
   test:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -67,3 +67,32 @@ jobs:
         run: |
           pip install -r backend/product_service/requirements-dev.txt
           pytest backend/product_service/tests/
+
+  build_and_push:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to Azure Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.ACR_LOGIN_SERVER }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Build and push customer service image
+        run: |
+          docker build -t ${{ secrets.ACR_LOGIN_SERVER }}/customer-service:${{ github.sha }} backend/customer_service
+          docker push ${{ secrets.ACR_LOGIN_SERVER }}/customer-service:${{ github.sha }}
+
+      - name: Build and push order service image
+        run: |
+          docker build -t ${{ secrets.ACR_LOGIN_SERVER }}/order-service:${{ github.sha }} backend/order_service
+          docker push ${{ secrets.ACR_LOGIN_SERVER }}/order-service:${{ github.sha }}
+
+      - name: Build and push product service image
+        run: |
+          docker build -t ${{ secrets.ACR_LOGIN_SERVER }}/product-service:${{ github.sha }} backend/product_service
+          docker push ${{ secrets.ACR_LOGIN_SERVER }}/product-service:${{ github.sha }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -96,3 +96,28 @@ jobs:
         run: |
           docker build -t ${{ secrets.ACR_LOGIN_SERVER }}/product-service:${{ github.sha }} backend/product_service
           docker push ${{ secrets.ACR_LOGIN_SERVER }}/product-service:${{ github.sha }}
+
+  deploy_staging:
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy customer service to staging
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: customer-service-staging
+          publish-profile: ${{ secrets.PUBLISH_PROFILE_CUSTOMER_STAGING }}
+          images: ${{ secrets.ACR_LOGIN_SERVER }}/customer-service:${{ github.sha }}
+
+      - name: Deploy order service to staging
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: order-service-staging
+          publish-profile: ${{ secrets.PUBLISH_PROFILE_ORDER_STAGING }}
+          images: ${{ secrets.ACR_LOGIN_SERVER }}/order-service:${{ github.sha }}
+
+      - name: Deploy product service to staging
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: product-service-staging
+          publish-profile: ${{ secrets.PUBLISH_PROFILE_PRODUCT_STAGING }}
+          images: ${{ secrets.ACR_LOGIN_SERVER }}/product-service:${{ github.sha }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -13,8 +13,8 @@ jobs:
         image: postgres:13
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: test_db
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: customers
         ports:
           - 5432:5432
         options: >-
@@ -34,21 +34,36 @@ jobs:
 
       - name: Install and Test Customer Service
         env:
-          DATABASE_URL: "postgresql://postgres:password@localhost:5432/test_db"
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: customers
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/customers"
         run: |
           pip install -r backend/customer_service/requirements-dev.txt
           pytest backend/customer_service/tests/
 
       - name: Install and Test Order Service
         env:
-          DATABASE_URL: "postgresql://postgres:password@localhost:5432/test_db"
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: customers
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/customers"
         run: |
           pip install -r backend/order_service/requirements-dev.txt
           pytest backend/order_service/tests/
 
       - name: Install and Test Product Service
         env:
-          DATABASE_URL: "postgresql://postgres:password@localhost:5432/test_db"
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: customers
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/customers"
         run: |
           pip install -r backend/product_service/requirements-dev.txt
           pytest backend/product_service/tests/

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - testing
+      - main
 
 jobs:
   test:
@@ -100,6 +101,7 @@ jobs:
   deploy_staging:
     needs: build_and_push
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/testing'
     steps:
       - name: Deploy customer service to staging
         uses: azure/webapps-deploy@v2
@@ -120,4 +122,33 @@ jobs:
         with:
           app-name: product-service-staging
           publish-profile: ${{ secrets.PUBLISH_PROFILE_PRODUCT_STAGING }}
+          images: ${{ secrets.ACR_LOGIN_SERVER }}/product-service:${{ github.sha }}
+
+  deploy_production:
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: production
+      url: https://customer-service-production.azurewebsites.net
+    steps:
+      - name: Deploy customer service to production
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: customer-service-production
+          publish-profile: ${{ secrets.PUBLISH_PROFILE_CUSTOMER_PRODUCTION }}
+          images: ${{ secrets.ACR_LOGIN_SERVER }}/customer-service:${{ github.sha }}
+
+      - name: Deploy order service to production
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: order-service-production
+          publish-profile: ${{ secrets.PUBLISH_PROFILE_ORDER_PRODUCTION }}
+          images: ${{ secrets.ACR_LOGIN_SERVER }}/order-service:${{ github.sha }}
+
+      - name: Deploy product service to production
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: product-service-production
+          publish-profile: ${{ secrets.PUBLISH_PROFILE_PRODUCT_PRODUCTION }}
           images: ${{ secrets.ACR_LOGIN_SERVER }}/product-service:${{ github.sha }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -6,8 +6,6 @@ on:
       - testing
       - main
 
-env:
-  DEPLOY_STAGING: ${{ vars.DEPLOY_STAGING || 'false' }}
 
 jobs:
   test:
@@ -104,7 +102,7 @@ jobs:
   deploy_staging:
     needs: build_and_push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/testing' && env.DEPLOY_STAGING == 'true'
+  if: github.ref == 'refs/heads/testing' && vars.DEPLOY_STAGING == 'true'
     steps:
       - name: Deploy customer service to staging
         uses: azure/webapps-deploy@v2

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Deployment credentials
+publish-profiles/

--- a/backend/customer_service/Dockerfile
+++ b/backend/customer_service/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+	PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends build-essential libpq-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT=8002
+EXPOSE 8002
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT}"]

--- a/backend/customer_service/app/db.py
+++ b/backend/customer_service/app/db.py
@@ -1,19 +1,56 @@
 import os
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+LOCALHOST_VALUES = {"localhost", "127.0.0.1"}
 
 POSTGRES_USER = os.getenv("POSTGRES_USER", "postgres")
 POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "customers")
 POSTGRES_HOST = os.getenv("POSTGRES_HOST", "localhost")
 POSTGRES_PORT = os.getenv("POSTGRES_PORT", "5432")
+POSTGRES_SSLMODE = os.getenv("POSTGRES_SSLMODE")
 
-DATABASE_URL = (
-    f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
-    f"{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
-)
+
+def _ensure_ssl(database_url: str) -> str:
+    parsed = urlparse(database_url)
+    hostname = parsed.hostname
+    if not hostname or hostname in LOCALHOST_VALUES:
+        return database_url
+
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    for key, _ in query_pairs:
+        if key.lower() == "sslmode":
+            return database_url
+
+    query_pairs.append(("sslmode", "require"))
+    new_query = urlencode(query_pairs)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def _build_database_url() -> str:
+    database_url_env = os.getenv("DATABASE_URL")
+    if database_url_env:
+        return _ensure_ssl(database_url_env)
+
+    sslmode = POSTGRES_SSLMODE
+    if (not sslmode) and POSTGRES_HOST not in LOCALHOST_VALUES:
+        sslmode = "require"
+
+    query = urlencode({"sslmode": sslmode}) if sslmode else ""
+    query_fragment = f"?{query}" if query else ""
+
+    constructed_url = (
+        f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
+        f"{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}{query_fragment}"
+    )
+    return _ensure_ssl(constructed_url)
+
+
+DATABASE_URL = _build_database_url()
 
 engine = create_engine(DATABASE_URL, pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/order_service/Dockerfile
+++ b/backend/order_service/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+	PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends build-essential libpq-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT=8003
+EXPOSE 8003
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT}"]

--- a/backend/order_service/app/db.py
+++ b/backend/order_service/app/db.py
@@ -1,19 +1,56 @@
 import os
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+LOCALHOST_VALUES = {"localhost", "127.0.0.1"}
 
 POSTGRES_USER = os.getenv("POSTGRES_USER", "postgres")
 POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "orders")
 POSTGRES_HOST = os.getenv("POSTGRES_HOST", "localhost")
 POSTGRES_PORT = os.getenv("POSTGRES_PORT", "5432")
+POSTGRES_SSLMODE = os.getenv("POSTGRES_SSLMODE")
 
-DATABASE_URL = (
-    f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
-    f"{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
-)
+
+def _ensure_ssl(database_url: str) -> str:
+    parsed = urlparse(database_url)
+    hostname = parsed.hostname
+    if not hostname or hostname in LOCALHOST_VALUES:
+        return database_url
+
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    for key, _ in query_pairs:
+        if key.lower() == "sslmode":
+            return database_url
+
+    query_pairs.append(("sslmode", "require"))
+    new_query = urlencode(query_pairs)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def _build_database_url() -> str:
+    database_url_env = os.getenv("DATABASE_URL")
+    if database_url_env:
+        return _ensure_ssl(database_url_env)
+
+    sslmode = POSTGRES_SSLMODE
+    if (not sslmode) and POSTGRES_HOST not in LOCALHOST_VALUES:
+        sslmode = "require"
+
+    query = urlencode({"sslmode": sslmode}) if sslmode else ""
+    query_fragment = f"?{query}" if query else ""
+
+    constructed_url = (
+        f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
+        f"{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}{query_fragment}"
+    )
+    return _ensure_ssl(constructed_url)
+
+
+DATABASE_URL = _build_database_url()
 
 engine = create_engine(DATABASE_URL, pool_pre_ping=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/order_service/app/main.py
+++ b/backend/order_service/app/main.py
@@ -42,6 +42,11 @@ logger.info(
     f"Order Service: Configured to communicate with Customer Service at: {CUSTOMER_SERVICE_URL}"
 )
 
+PRODUCT_SERVICE_URL = os.getenv("PRODUCT_SERVICE_URL", "http://localhost:8001")
+logger.info(
+    f"Order Service: Configured to communicate with Product Service at: {PRODUCT_SERVICE_URL}"
+)
+
 
 # --- RabbitMQ Configuration ---
 RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "localhost")

--- a/backend/product_service/Dockerfile
+++ b/backend/product_service/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+	PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends build-essential libpq-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT=8001
+EXPOSE 8001
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT}"]

--- a/backend/product_service/app/db.py
+++ b/backend/product_service/app/db.py
@@ -1,8 +1,12 @@
 import os
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+
+LOCALHOST_VALUES = {"localhost", "127.0.0.1"}
 
 
 POSTGRES_USER = os.getenv("POSTGRES_USER", "postgres")
@@ -10,12 +14,46 @@ POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "products")
 POSTGRES_HOST = os.getenv("POSTGRES_HOST", "localhost")
 POSTGRES_PORT = os.getenv("POSTGRES_PORT", "5432")
+POSTGRES_SSLMODE = os.getenv("POSTGRES_SSLMODE")
 
-DATABASE_URL = (
-    "postgresql://"
-    f"{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
-    f"{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
-)
+
+def _ensure_ssl(database_url: str) -> str:
+    parsed = urlparse(database_url)
+    hostname = parsed.hostname
+    if not hostname or hostname in LOCALHOST_VALUES:
+        return database_url
+
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    for key, _ in query_pairs:
+        if key.lower() == "sslmode":
+            return database_url
+
+    query_pairs.append(("sslmode", "require"))
+    new_query = urlencode(query_pairs)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def _build_database_url() -> str:
+    database_url_env = os.getenv("DATABASE_URL")
+    if database_url_env:
+        return _ensure_ssl(database_url_env)
+
+    sslmode = POSTGRES_SSLMODE
+    if (not sslmode) and POSTGRES_HOST not in LOCALHOST_VALUES:
+        sslmode = "require"
+
+    query = urlencode({"sslmode": sslmode}) if sslmode else ""
+    query_fragment = f"?{query}" if query else ""
+
+    constructed_url = (
+        "postgresql://"
+        f"{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
+        f"{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}{query_fragment}"
+    )
+    return _ensure_ssl(constructed_url)
+
+
+DATABASE_URL = _build_database_url()
 
 # --- SQLAlchemy Engine and Session Setup ---
 engine = create_engine(DATABASE_URL)


### PR DESCRIPTION
## Summary
- append sslmode=require whenever a database URL points to a non-local host
- allow DATABASE_URL env vars from Azure and still enforce SSL
- verified with pytest suites for customer, order, and product services against a live Postgres container

## Testing
- backend/customer_service: python -m pytest
- backend/order_service: python -m pytest
- backend/product_service: python -m pytest

## Notes
Production /health is still 503 until this PR merges into main and the pipeline deploys the new images.